### PR TITLE
Created a command scheduler. Fixed #23

### DIFF
--- a/src/org/rocketproplab/marginalstability/flightcomputer/commands/Command.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/commands/Command.java
@@ -16,7 +16,7 @@ public interface Command {
   /**
    * Returns whether the command has finished execution.
    */
-  public void isDone();
+  public boolean isDone();
 
   /**
    * Called by the scheduler every xx ms while the command is not done

--- a/src/org/rocketproplab/marginalstability/flightcomputer/commands/CommandScheduler.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/commands/CommandScheduler.java
@@ -24,6 +24,7 @@ public class CommandScheduler {
 
   /**
    * Gets the singleton instance of CommandScheduler.
+   * 
    * @return Instance of CommandScheduler.
    */
   public static CommandScheduler getInstance() {
@@ -32,72 +33,77 @@ public class CommandScheduler {
     }
     return instance;
   }
-  
+
   /**
    * List storing all commands that are running.
    */
   private ArrayList<Command> active;
-  
+
   /**
-   * List storing commands awaiting execution.
+   * List storing all commands awaiting execution.
    */
-  private ArrayList<Command> queue;  
+  private ArrayList<Command> queue;
 
   /**
    * Constructor.
    */
   public CommandScheduler() {
     active = new ArrayList<Command>();
-    queue = new ArrayList<Command>();
+    queue  = new ArrayList<Command>();
   }
-  
+
   /**
-   * Add command waiting for execution to queue.
-   * @param command
+   * Add command to queue. It will be executed when it's subsystem dependencies
+   * are available.
+   * 
+   * @param command Command to add.
    */
   public void scheduleCommand(Command command) {
-    if (!queue.contains(command) && !command.isDone()) {
+    if (!queue.contains(command) && !active.contains(command)
+        && !command.isDone()) {
       queue.add(command);
     }
   }
-  
+
   /**
    * Called every interval. Processes the queue.
    */
   public void tick() {
     List<Subsystem> busySubsystems = new ArrayList<Subsystem>();
-    
+
     // Process active commands.
     Iterator<Command> activeCmdsIterator = active.iterator();
     while (activeCmdsIterator.hasNext()) {
       // Get next active command in list.
       Command command = activeCmdsIterator.next();
+      
       if (command.isDone()) {
         // Remove the last command from the active list.
         activeCmdsIterator.remove();
       } else {
-        // Get the command's dependencies.
+        // Add all of the command's dependencies to busySubsystems.
         busySubsystems.addAll(Arrays.asList(command.getDependencies()));
+        
         // Invoke command's execute method.
         command.execute();
       }
     }
-    
+
     // Process queue.
     Iterator<Command> queueIterator = queue.iterator();
     while (queueIterator.hasNext()) {
       // Get next command in queue and it's dependencies.
-      Command command = queueIterator.next();
+      Command         command      = queueIterator.next();
       List<Subsystem> dependencies = Arrays.asList(command.getDependencies());
-      
+
       // Check if command has no dependencies that are in-use.
       if (Collections.disjoint(dependencies, busySubsystems)) {
-        queueIterator.remove();  // Remove command from queue.
-        command.start();         // Start command execution.
-        command.execute();
-        active.add(command);     // Add command to active list.
+        queueIterator.remove(); // Remove command from queue.
+        command.start();        // Start command execution.
+        command.execute();      // Execute command.
+        active.add(command);    // Add command to active list.
       }
-      
+
       // Add all of command's dependencies to busySubsystems list.
       for (int d = 0; d < dependencies.size(); d++) {
         if (!busySubsystems.contains(dependencies.get(d))) {

--- a/src/org/rocketproplab/marginalstability/flightcomputer/commands/CommandScheduler.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/commands/CommandScheduler.java
@@ -3,6 +3,8 @@ package org.rocketproplab.marginalstability.flightcomputer.commands;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
@@ -10,7 +12,7 @@ import org.rocketproplab.marginalstability.flightcomputer.subsystems.Subsystem;
 
 /**
  * Responsible for running commands. Determines when it should run a command
- * based on the states of the required subsystems.
+ * based on the state of required subsystems.
  * 
  * @author Enlil Odisho
  *
@@ -45,51 +47,57 @@ public class CommandScheduler {
   private ArrayList<Command> queue;
 
   /**
+   * Hash map containing all subsystems that are being used along with the
+   * command that's using them.
+   */
+  private HashMap<Subsystem, Command> busySubsystems;
+
+  /**
    * Constructor.
    */
   public CommandScheduler() {
-    active = new ArrayList<Command>();
-    queue  = new ArrayList<Command>();
+    active         = new ArrayList<Command>();
+    queue          = new ArrayList<Command>();
+    busySubsystems = new HashMap<Subsystem, Command>();
   }
 
   /**
-   * Add command to queue. It will be executed when it's subsystem dependencies
-   * are available.
+   * Add command to command scheduler queue. It will be executed when it's
+   * subsystem dependencies are available.
    * 
    * @param command Command to add.
    */
   public void scheduleCommand(Command command) {
-    if (!queue.contains(command) && !active.contains(command)
-        && !command.isDone()) {
+    // Make sure command is not done and not already in scheduler.
+    if (!command.isDone() && !queue.contains(command)
+        && !active.contains(command)) {
       queue.add(command);
     }
   }
 
   /**
-   * Called every interval. Processes the queue.
+   * Retrieves the command that is using a particular subsystem. Returns null if
+   * subsystem is not being used by any command.
+   * 
+   * @param subsystem Subsystem that is being used by command.
+   */
+  public Command getCommandUsingSubsystem(Subsystem subsystem) {
+    return busySubsystems.get(subsystem);
+  }
+
+  /**
+   * Called every interval.
    */
   public void tick() {
-    List<Subsystem> busySubsystems = new ArrayList<Subsystem>();
-
     // Process active commands.
-    Iterator<Command> activeCmdsIterator = active.iterator();
-    while (activeCmdsIterator.hasNext()) {
-      // Get next active command in list.
-      Command command = activeCmdsIterator.next();
-      
-      if (command.isDone()) {
-        // Remove the last command from the active list.
-        activeCmdsIterator.remove();
-      } else {
-        // Add all of the command's dependencies to busySubsystems.
-        busySubsystems.addAll(Arrays.asList(command.getDependencies()));
-        
-        // Invoke command's execute method.
-        command.execute();
-      }
-    }
+    updateActiveCommands();
 
     // Process queue.
+    // Stores the list of subsystems not available to be used.
+    HashSet<Subsystem> unavailableSubsystems = new HashSet<Subsystem>(
+        busySubsystems.keySet());
+
+    // Loop through all commands in queue.
     Iterator<Command> queueIterator = queue.iterator();
     while (queueIterator.hasNext()) {
       // Get next command in queue and it's dependencies.
@@ -97,18 +105,45 @@ public class CommandScheduler {
       List<Subsystem> dependencies = Arrays.asList(command.getDependencies());
 
       // Check if command has no dependencies that are in-use.
-      if (Collections.disjoint(dependencies, busySubsystems)) {
+      if (Collections.disjoint(dependencies, unavailableSubsystems)) {
+        // Start running command.
         queueIterator.remove(); // Remove command from queue.
-        command.start();        // Start command execution.
-        command.execute();      // Execute command.
-        active.add(command);    // Add command to active list.
+        active.add(command); // Add command to active list.
+        command.start(); // Start command execution.
+        command.execute(); // Execute command.
+        // Mark command's dependencies as busy.
+        for (Subsystem s : dependencies) {
+          busySubsystems.put(s, command);
+        }
       }
 
-      // Add all of command's dependencies to busySubsystems list.
-      for (int d = 0; d < dependencies.size(); d++) {
-        if (!busySubsystems.contains(dependencies.get(d))) {
-          busySubsystems.add(dependencies.get(d));
+      // Add all of command's dependencies to unavailableSubsystems list.
+      // This prevents us from running a command that uses a dependency that
+      // a command earlier in the queue needs.
+      unavailableSubsystems.addAll(dependencies);
+    }
+  }
+
+  /**
+   * Updates the active and busy subsystems lists. Should be called every tick().
+   */
+  private void updateActiveCommands() {
+    // Loop through all active commands.
+    Iterator<Command> activeCmdsIterator = active.iterator();
+    while (activeCmdsIterator.hasNext()) {
+      Command command = activeCmdsIterator.next();
+
+      if (command.isDone()) {
+        // Remove the command from active list.
+        activeCmdsIterator.remove();
+        // Make command's dependencies available for other commands to use.
+        Subsystem[] subsystemsUsed = command.getDependencies();
+        for (Subsystem s : subsystemsUsed) {
+          busySubsystems.remove(s, command);
         }
+      } else {
+        // Invoke command's execute method.
+        command.execute();
       }
     }
   }

--- a/src/org/rocketproplab/marginalstability/flightcomputer/commands/CommandScheduler.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/commands/CommandScheduler.java
@@ -1,0 +1,91 @@
+package org.rocketproplab.marginalstability.flightcomputer.commands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Queue;
+
+import org.rocketproplab.marginalstability.flightcomputer.subsystems.Subsystem;
+
+/**
+ * Responsible for running commands. Determines when it should run a command
+ * based on the states of the required subsystems.
+ * 
+ * @author Enlil Odisho
+ *
+ */
+public class CommandScheduler {
+
+  /**
+   * Static variable containing an instance of CommandScheduler.
+   */
+  private static CommandScheduler instance = null;
+
+  /**
+   * Gets the singleton instance of CommandScheduler.
+   * @return Instance of CommandScheduler.
+   */
+  public static CommandScheduler getInstance() {
+    if (instance == null) {
+      instance = new CommandScheduler();
+    }
+    return instance;
+  }
+  
+  /**
+   * List storing all commands that are running.
+   */
+  private ArrayList<Command> active;
+  
+  /**
+   * List storing commands awaiting execution.
+   */
+  private ArrayList<Command> queue;  
+
+  /**
+   * Constructor for Command Scheduler.
+   */
+  public CommandScheduler() {
+    active = new ArrayList<Command>();
+    queue = new ArrayList<Command>();
+  }
+  
+  /**
+   * Add command waiting for execution to queue.
+   * @param command
+   */
+  public void scheduleCommand(Command command) {
+    if (!queue.contains(command) && !command.isDone()) {
+      queue.add(command);
+    }
+  }
+  
+  /**
+   * Called every interval. Processes the queue.
+   */
+  public void tick() {
+    // TODO implement method
+  }
+  
+  /* old code
+  /**
+   * Called every xx interval.
+   *
+  public void tick() {
+    ArrayList<Subsystem> busySubsystems = new ArrayList<Subsystem>();
+    
+    // Iterate over started commands and check if completed, otherwise execute.
+    Iterator<Command> startedcmdsIterator = started.iterator();
+    while (startedcmdsIterator.hasNext()) {
+      Command command = startedcmdsIterator.next();
+      if (command.isDone()) {
+        // Command is done, remove from started list.
+        startedcmdsIterator.remove();
+      } else {
+        // Command is not done, add all dependencies to busySubsystems.
+        busySubsystems.addAll(Arrays.asList(command.getDependencies()));
+      }
+    }
+  }*/
+
+}

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
@@ -23,7 +23,7 @@ public class DummyCommand implements Command {
    * Number of times execute must be called until command is done.
    */
   public int doneAfter = 1;
-  
+
   /**
    * Number of times execute has been called.
    */

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
@@ -15,18 +15,19 @@ public class DummyCommand implements Command {
   public boolean done = false;
 
   /**
-   * Whether the command has been started by the scheduler;
+   * Whether the command has been started by the scheduler.
    */
   public boolean started = false;
 
   /**
    * Number of times execute must be called until command is done.
    */
-  public int  doneAfter = 1;
+  public int doneAfter = 1;
+  
   /**
    * Number of times execute has been called.
    */
-  private int counter   = 0;
+  private int counter = 0;
 
   @Override
   public boolean isDone() {

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
@@ -1,0 +1,59 @@
+package org.rocketproplab.marginalstability.flightcomputer.commands;
+
+import org.rocketproplab.marginalstability.flightcomputer.subsystems.Subsystem;
+
+public class DummyCommand implements Command {
+
+  /**
+   * The subsystem dependencies for the command.
+   */
+  public Subsystem[] dependencies = new Subsystem[] {};
+
+  /**
+   * Whether the command is done.
+   */
+  public boolean done = false;
+
+  /**
+   * Whether the command has been started by the scheduler;
+   */
+  public boolean started = false;
+
+  /**
+   * Number of times execute must be called until command is done.
+   */
+  public int  doneAfter = 1;
+  /**
+   * Number of times execute has been called.
+   */
+  private int counter   = 0;
+
+  @Override
+  public boolean isDone() {
+    return done;
+  }
+
+  @Override
+  public void execute() {
+    counter++;
+    if (counter >= doneAfter) {
+      done = true;
+    }
+  }
+
+  @Override
+  public void start() {
+    started = true;
+  }
+
+  @Override
+  public void end() {
+    started = false;
+  }
+
+  @Override
+  public Subsystem[] getDependencies() {
+    return dependencies;
+  }
+
+}

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummyCommand.java
@@ -29,6 +29,10 @@ public class DummyCommand implements Command {
    */
   private int counter = 0;
 
+  public int getNumberOfTimesExecuted() {
+    return counter;
+  }
+  
   @Override
   public boolean isDone() {
     return done;

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummySubsystem.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/DummySubsystem.java
@@ -1,0 +1,11 @@
+package org.rocketproplab.marginalstability.flightcomputer.commands;
+
+import org.rocketproplab.marginalstability.flightcomputer.subsystems.Subsystem;
+
+public class DummySubsystem implements Subsystem {
+
+  @Override
+  public void update() {
+  }
+
+}

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
@@ -6,51 +6,129 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.rocketproplab.marginalstability.flightcomputer.subsystems.Subsystem;
 
 public class TestCommandScheduler {
-  
+
   @Test
   public void checkSingletonInstance() {
     // get an instance of command scheduler
     CommandScheduler singletonInstance = CommandScheduler.getInstance();
-    
+
     // instance should never be null
     assertNotNull(singletonInstance);
-    
+
     // create a new command scheduler
     CommandScheduler differentScheduler = new CommandScheduler();
-    
+
     // new command scheduler must be different than singleton instance
     assertNotEquals(differentScheduler, singletonInstance);
   }
-  
+
   @Test
   public void testScheduleCommandsWithNoDependencies() {
     DummyCommand command1 = new DummyCommand();
     command1.doneAfter = 3;
     DummyCommand command2 = new DummyCommand();
     command2.doneAfter = 1;
-    
+
     CommandScheduler.getInstance().scheduleCommand(command1);
     CommandScheduler.getInstance().scheduleCommand(command2);
-    
+
     assertFalse(command1.isDone());
     assertFalse(command2.isDone());
-    
+
     CommandScheduler.getInstance().tick();
-    
+
     assertFalse(command1.isDone());
     assertTrue(command2.isDone());
-    
+
     CommandScheduler.getInstance().tick();
-    
+
     assertFalse(command1.isDone());
     assertTrue(command2.isDone());
-    
+
     CommandScheduler.getInstance().tick();
-    
+
     assertTrue(command1.isDone());
     assertTrue(command2.isDone());
   }
-  
+
+  /**
+   * Tests scenarios:
+   * 
+   * 1. Command 1 in queue depends on subsystem A, command 2 depends on
+   * subsystems A and B, and command 3 depends on subsystem B.
+   * Expected order of commands: 1, 2, 3.
+   * Even though command 3 could run while command 1 is running, if we did
+   * that then we would be blocking command 2 from running since it depends
+   * on both subsystems A and B. Thus command 3 must not run until command 2
+   * is done.
+   * 
+   * 2. Command 3 depends on subsystem B and command 4 depends on subsystems
+   * A and C.
+   * Expected order of commands: 3 & 4 in parallel
+   * Since commands 3 and 4 do not require the same dependencies, they should
+   * both run together.
+   * 
+   */
+  @Test
+  public void testScheduleCommandsWithDependencies() {
+    Subsystem subsystemA = new DummySubsystem();
+    Subsystem subsystemB = new DummySubsystem();
+    Subsystem subsystemC = new DummySubsystem();
+
+    // Create dummy commands.
+    DummyCommand command1 = new DummyCommand();
+    command1.dependencies = new Subsystem[] { subsystemA };
+    command1.doneAfter    = 2;
+    DummyCommand command2 = new DummyCommand();
+    command2.dependencies = new Subsystem[] { subsystemA, subsystemB };
+    command2.doneAfter    = 1;
+    DummyCommand command3 = new DummyCommand();
+    command3.dependencies = new Subsystem[] { subsystemB };
+    command3.doneAfter    = 1;
+    DummyCommand command4 = new DummyCommand();
+    command4.dependencies = new Subsystem[] { subsystemA, subsystemC };
+    command4.doneAfter    = 1;
+
+    // Add all commands to scheduler
+    CommandScheduler.getInstance().scheduleCommand(command1);
+    CommandScheduler.getInstance().scheduleCommand(command2);
+    CommandScheduler.getInstance().scheduleCommand(command3);
+
+    assertFalse(command1.isDone());
+    assertFalse(command2.isDone());
+    assertFalse(command3.isDone());
+    assertFalse(command4.isDone());
+
+    CommandScheduler.getInstance().tick();
+
+    assertFalse(command1.isDone());
+    assertFalse(command2.isDone());
+    assertFalse(command3.isDone());
+    assertFalse(command4.isDone());
+
+    CommandScheduler.getInstance().tick();
+
+    assertTrue(command1.isDone());
+    assertFalse(command2.isDone());
+    assertFalse(command3.isDone());
+    assertFalse(command4.isDone());
+
+    CommandScheduler.getInstance().tick();
+
+    assertTrue(command1.isDone());
+    assertTrue(command2.isDone());
+    assertFalse(command3.isDone());
+    assertFalse(command4.isDone());
+
+    CommandScheduler.getInstance().tick();
+
+    assertTrue(command1.isDone());
+    assertTrue(command2.isDone());
+    assertTrue(command3.isDone());
+    assertTrue(command4.isDone());
+  }
+
 }

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
@@ -1,0 +1,56 @@
+package org.rocketproplab.marginalstability.flightcomputer.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TestCommandScheduler {
+  
+  @Test
+  public void checkSingletonInstance() {
+    // get an instance of command scheduler
+    CommandScheduler singletonInstance = CommandScheduler.getInstance();
+    
+    // instance should never be null
+    assertNotNull(singletonInstance);
+    
+    // create a new command scheduler
+    CommandScheduler differentScheduler = new CommandScheduler();
+    
+    // new command scheduler must be different than singleton instance
+    assertNotEquals(differentScheduler, singletonInstance);
+  }
+  
+  @Test
+  public void testScheduleCommandsWithNoDependencies() {
+    DummyCommand command1 = new DummyCommand();
+    command1.doneAfter = 3;
+    DummyCommand command2 = new DummyCommand();
+    command2.doneAfter = 1;
+    
+    CommandScheduler.getInstance().scheduleCommand(command1);
+    CommandScheduler.getInstance().scheduleCommand(command2);
+    
+    assertFalse(command1.isDone());
+    assertFalse(command2.isDone());
+    
+    CommandScheduler.getInstance().tick();
+    
+    assertFalse(command1.isDone());
+    assertTrue(command2.isDone());
+    
+    CommandScheduler.getInstance().tick();
+    
+    assertFalse(command1.isDone());
+    assertTrue(command2.isDone());
+    
+    CommandScheduler.getInstance().tick();
+    
+    assertTrue(command1.isDone());
+    assertTrue(command2.isDone());
+  }
+  
+}

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
@@ -69,7 +69,7 @@ public class TestCommandScheduler {
    * A and C.
    * Expected order of commands: 3 & 4 in parallel
    * Since commands 3 and 4 do not require the same dependencies, they should
-   * both run together.
+   * both run at the same time.
    * 
    */
   @Test
@@ -96,6 +96,7 @@ public class TestCommandScheduler {
     CommandScheduler.getInstance().scheduleCommand(command1);
     CommandScheduler.getInstance().scheduleCommand(command2);
     CommandScheduler.getInstance().scheduleCommand(command3);
+    CommandScheduler.getInstance().scheduleCommand(command4);
 
     assertFalse(command1.isDone());
     assertFalse(command2.isDone());

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
@@ -30,8 +30,9 @@ public class TestCommandScheduler {
 
   @Test
   public void testScheduleSameCommandMultipleTimes() {
-    CommandScheduler cs       = CommandScheduler.getInstance();
+    CommandScheduler cs       = new CommandScheduler();
     DummyCommand     command1 = new DummyCommand();
+    
     cs.scheduleCommand(command1);
     cs.scheduleCommand(command1);
     cs.scheduleCommand(command1);
@@ -59,7 +60,7 @@ public class TestCommandScheduler {
 
   @Test
   public void testSchedulerGetCommandUsingSubsystem() {
-    CommandScheduler cs = CommandScheduler.getInstance();
+    CommandScheduler cs = new CommandScheduler();
 
     DummySubsystem sA = new DummySubsystem();
     DummySubsystem sB = new DummySubsystem();
@@ -101,28 +102,30 @@ public class TestCommandScheduler {
 
   @Test
   public void testScheduleCommandsWithNoDependencies() {
+    CommandScheduler cs = new CommandScheduler();
+    
     DummyCommand command1 = new DummyCommand();
     command1.doneAfter = 3;
     DummyCommand command2 = new DummyCommand();
     command2.doneAfter = 1;
 
-    CommandScheduler.getInstance().scheduleCommand(command1);
-    CommandScheduler.getInstance().scheduleCommand(command2);
+    cs.scheduleCommand(command1);
+    cs.scheduleCommand(command2);
 
     assertFalse(command1.isDone());
     assertFalse(command2.isDone());
 
-    CommandScheduler.getInstance().tick();
+    cs.tick();
 
     assertFalse(command1.isDone());
     assertTrue(command2.isDone());
 
-    CommandScheduler.getInstance().tick();
+    cs.tick();
 
     assertFalse(command1.isDone());
     assertTrue(command2.isDone());
 
-    CommandScheduler.getInstance().tick();
+    cs.tick();
 
     assertTrue(command1.isDone());
     assertTrue(command2.isDone());
@@ -146,6 +149,8 @@ public class TestCommandScheduler {
    */
   @Test
   public void testScheduleCommandsWithDependencies() {
+    CommandScheduler cs = new CommandScheduler();
+    
     Subsystem subsystemA = new DummySubsystem();
     Subsystem subsystemB = new DummySubsystem();
     Subsystem subsystemC = new DummySubsystem();
@@ -167,11 +172,11 @@ public class TestCommandScheduler {
     command5.doneAfter    = 1;
 
     // Add all commands to scheduler
-    CommandScheduler.getInstance().scheduleCommand(command1);
-    CommandScheduler.getInstance().scheduleCommand(command2);
-    CommandScheduler.getInstance().scheduleCommand(command3);
-    CommandScheduler.getInstance().scheduleCommand(command4);
-    CommandScheduler.getInstance().scheduleCommand(command5);
+    cs.scheduleCommand(command1);
+    cs.scheduleCommand(command2);
+    cs.scheduleCommand(command3);
+    cs.scheduleCommand(command4);
+    cs.scheduleCommand(command5);
 
     assertFalse(command1.isDone());
     assertFalse(command2.isDone());
@@ -179,7 +184,7 @@ public class TestCommandScheduler {
     assertFalse(command4.isDone());
     assertFalse(command5.isDone());
 
-    CommandScheduler.getInstance().tick();
+    cs.tick();
 
     assertFalse(command1.isDone());
     assertFalse(command2.isDone());
@@ -187,7 +192,7 @@ public class TestCommandScheduler {
     assertFalse(command4.isDone());
     assertTrue(command5.isDone());
 
-    CommandScheduler.getInstance().tick();
+    cs.tick();
 
     assertTrue(command1.isDone());
     assertFalse(command2.isDone());
@@ -195,7 +200,7 @@ public class TestCommandScheduler {
     assertFalse(command4.isDone());
     assertTrue(command5.isDone());
 
-    CommandScheduler.getInstance().tick();
+    cs.tick();
 
     assertTrue(command1.isDone());
     assertTrue(command2.isDone());
@@ -203,7 +208,7 @@ public class TestCommandScheduler {
     assertFalse(command4.isDone());
     assertTrue(command5.isDone());
 
-    CommandScheduler.getInstance().tick();
+    cs.tick();
 
     assertTrue(command1.isDone());
     assertTrue(command2.isDone());

--- a/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/commands/TestCommandScheduler.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.rocketproplab.marginalstability.flightcomputer.subsystems.DummySubsystem;
 import org.rocketproplab.marginalstability.flightcomputer.subsystems.Subsystem;
 
 public class TestCommandScheduler {

--- a/test/org/rocketproplab/marginalstability/flightcomputer/subsystems/DummySubsystem.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/subsystems/DummySubsystem.java
@@ -1,4 +1,4 @@
-package org.rocketproplab.marginalstability.flightcomputer.commands;
+package org.rocketproplab.marginalstability.flightcomputer.subsystems;
 
 import org.rocketproplab.marginalstability.flightcomputer.subsystems.Subsystem;
 


### PR DESCRIPTION
Added a command scheduler in order to delay running commands that need to use subsystems that are being used by other commands.

The command scheduler has a queue and runs as many commands as it can in parallel, that do not depend on the same subsystems. See #23 for more details.

My implementation of CommandScheduler contains the following public methods:

- getInstance(): Get an instance of command scheduler (singleton)
- scheduleCommand(): To add a command to the command scheduler's queue
- getCommandUsingSubsystem(): Gets the command that is using a particular subsystem
- tick(): Should be called consistently every xx ms. This method checks on running commands & calls execute on them, then processes the queue.

To unit test this I created DummyCommand and DummySubsystem. DummyCommand contains a variable called _doneAfter_ that allows you to specify a number of times execute must be called until it marks itself as done. This is just to make it possible to unit test since it's not an actual command.