### PR TITLE
Use range of LSM9DS1 to normalize readings. Fixed #54

### DIFF
--- a/src/org/rocketproplab/marginalstability/flightcomputer/Settings.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/Settings.java
@@ -78,13 +78,17 @@ public class Settings {
   
   @SettingSectionHeader(name = "LSM9DS1 settings")
   
-  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_2G  = 0.00006103;
-  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_4G  = 0.00012207;
-  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_8G  = 0.00024414;
-  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_16G = 0.000732;
-  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_245DPS  = 0.00875;
-  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_500DPS  = 0.0175;
-  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_2000DPS = 0.07;
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_2G     = 0.00006103;
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_4G     = 0.00012207;
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_8G     = 0.00024414;
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_16G    = 0.000732;
+  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_245DPS     = 0.00875;
+  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_500DPS     = 0.0175;
+  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_2000DPS    = 0.07;
+  public static double LSM9DS1_SENSITIVITY_MAGNETOMETER_4GAUSS  = 0.00014;
+  public static double LSM9DS1_SENSITIVITY_MAGNETOMETER_8GAUSS  = 0.00029;
+  public static double LSM9DS1_SENSITIVITY_MAGNETOMETER_12GAUSS = 0.00043;
+  public static double LSM9DS1_SENSITIVITY_MAGNETOMETER_16GAUSS = 0.00058;
 
   private static Set<Field> getSettingFields() {
     Set<Field> result = new LinkedHashSet<>();

--- a/src/org/rocketproplab/marginalstability/flightcomputer/Settings.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/Settings.java
@@ -75,6 +75,16 @@ public class Settings {
 
   @UserSetting(comment = "Frequency of reference oscillator for the MAX14830, currently a LFXTAL003260 labeled X1 in the schematic.", units = "Hz")
   public static int MAX14830_F_REF = 3686400;
+  
+  @SettingSectionHeader(name = "LSM9DS1 settings")
+  
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_2G  = 0.00006103;
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_4G  = 0.00012207;
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_8G  = 0.00024414;
+  public static double LSM9DS1_SENSITIVITY_ACCELEROMETER_16G = 0.000732;
+  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_245DPS  = 0.00875;
+  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_500DPS  = 0.0175;
+  public static double LSM9DS1_SENSITIVITY_GYROSCOPE_2000DPS = 0.07;
 
   private static Set<Field> getSettingFields() {
     Set<Field> result = new LinkedHashSet<>();

--- a/src/org/rocketproplab/marginalstability/flightcomputer/hal/AccelGyroReading.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/hal/AccelGyroReading.java
@@ -7,7 +7,7 @@ import org.rocketproplab.marginalstability.flightcomputer.math.Vector3;
  * IMU at an instant. It consists of an acceleration vector as well as a
  * rotation difference. <br>
  * 
- * The rotation vector specified how many degrees were rotated in the last
+ * The rotation vector specified how many radians were rotated in the last
  * timestep in the local reference frame. <br>
  * The acceleration vector is the acceleration felt by the IMU in the local
  * reference frame in meters / second^2. If the IMU is lying flat on a table it
@@ -33,7 +33,7 @@ public class AccelGyroReading {
   }
 
   /**
-   * Get the rotation delta in the given reference frame in degrees.
+   * Get the rotation delta in the given reference frame in radians.
    * 
    * @return the difference in rotation from the last reading.
    */

--- a/src/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyro.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyro.java
@@ -454,7 +454,7 @@ public class LSM9DS1AccelGyro implements PollingSensor, AccelerometerGyroscope {
 
   /**
    * Parse a set of BYTES_PER_FIFO_LINE bytes into an AccelGyroReading. <br>
-   * TODO Use range to normalize to m/s^2
+   * Use range to normalize to m/s^2
    * 
    * @param data the set of six bytes representing a reading
    * @return the AccelGyroReading which the six bytes belong to.

--- a/src/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyro.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyro.java
@@ -50,9 +50,9 @@ public class LSM9DS1AccelGyro implements PollingSensor, AccelerometerGyroscope {
   public static final int  FIFO_SAMPLES_STORED_MASK    = 0b111111;
 
   private static final int BYTES_PER_FIFO_LINE    = 12;
-  private static final int BITS_PER_BYTE          = 8;
   
-  public static final double ACCELEROMETER_OUTPUT_TO_MPS_SQUARED = 9.80665;  // factor to convert sensor output to m/s^2
+  public static final double ACCELEROMETER_OUTPUT_TO_MPS_SQUARED = 9.81;  // factor to multiply acc output by to
+                                                                          // convert sensor output to m/s^2
   private static final double ONE_DEGREE_IN_RADIANS  = Math.PI / 180.0;
 
   /**

--- a/src/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyro.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyro.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 
 import org.rocketproplab.marginalstability.flightcomputer.ErrorReporter;
 import org.rocketproplab.marginalstability.flightcomputer.Errors;
+import org.rocketproplab.marginalstability.flightcomputer.Settings;
 import org.rocketproplab.marginalstability.flightcomputer.math.Vector3;
 
 import com.pi4j.io.i2c.I2CDevice;
@@ -48,11 +49,11 @@ public class LSM9DS1AccelGyro implements PollingSensor, AccelerometerGyroscope {
   public static final int  FIFO_THRESHOLD_STATUS_POS   = 7;
   public static final int  FIFO_SAMPLES_STORED_MASK    = 0b111111;
 
-  private static final int   BYTES_PER_FIFO_LINE    = 12;
-  private static final int   BITS_PER_BYTE          = 8;
+  private static final int BYTES_PER_FIFO_LINE    = 12;
+  private static final int BITS_PER_BYTE          = 8;
   
-  private static final int    MAX_RAW_SENSOR_READING = 32767;
-  private static final double G_FORCE                = 9.80665;  // gravity at Earth's surface
+  public static final double ACCELEROMETER_OUTPUT_TO_MPS_SQUARED = 9.80665;  // factor to convert sensor output to m/s^2
+  private static final double ONE_DEGREE_IN_RADIANS  = Math.PI / 180.0;
 
   /**
    * All the registers that can be found in the LSM9DS1 imu for the accelerometer
@@ -194,7 +195,7 @@ public class LSM9DS1AccelGyro implements PollingSensor, AccelerometerGyroscope {
    * The current gyroscope scale the sensor is set to.
    * Initialize to default value as specified in sensor datasheet.
    */
-  private GyroScale gyroScale = GyroScale.DPS_NA;
+  private GyroScale gyroScale = GyroScale.DPS_245;
 
   public enum FIFOMode implements RegisterValue {
     BYPASS,
@@ -468,8 +469,8 @@ public class LSM9DS1AccelGyro implements PollingSensor, AccelerometerGyroscope {
     int yAcc  = results[4];
     int zAcc  = results[5];
 
-    Vector3 gyroVec = new Vector3(xGyro, yGyro, zGyro);
-    Vector3 accVec  = new Vector3(xAcc, yAcc, zAcc);
+    Vector3 gyroVec = computeAngularAcceleration(xGyro, yGyro, zGyro);
+    Vector3 accVec  = computeAcceleration(xAcc, yAcc, zAcc);
     return new AccelGyroReading(accVec, gyroVec);
   }
 
@@ -501,39 +502,73 @@ public class LSM9DS1AccelGyro implements PollingSensor, AccelerometerGyroscope {
   }
   
   /**
-   * Get's sensor output and converts it to m/s^2. Uses the current sensor scale setting.
-   * @param accVec the accelerometer sensor output
-   * @return the acceleration in m/s^2
+   * Converts accelerometer readings to m/s^2. Uses the current accelerometer scale setting.
+   * @param accX x-axis reading from accelerometer
+   * @param accY y-axis reading from accelerometer
+   * @param accZ z-axis reading from accelerometer
+   * @return the acceleration vector in m/s^2
    */
-  public Vector3 computeAcceleration(Vector3 accVec)
-  {
-    // Get the accelerometer scale as a double.
-    double scale;
-    switch(accelScale)
-    {
+  public Vector3 computeAcceleration(int accX, int accY, int accZ) {
+    // Get the accelerometer sensitivity.
+    double sensitivity;
+    switch(accelScale) {
     case G_2:
-      scale = 2.0;
+      sensitivity = Settings.LSM9DS1_SENSITIVITY_ACCELEROMETER_2G;
       break;
     case G_4:
-      scale = 4.0;
+      sensitivity = Settings.LSM9DS1_SENSITIVITY_ACCELEROMETER_4G;
       break;
     case G_8:
-      scale = 8.0;
+      sensitivity = Settings.LSM9DS1_SENSITIVITY_ACCELEROMETER_8G;
       break;
     case G_16:
-      scale = 16.0;
+      sensitivity = Settings.LSM9DS1_SENSITIVITY_ACCELEROMETER_16G;
       break;
     default:
       throw new IllegalStateException("Sensor has an unknown accelerometer scale.");
     }
     
     // This factor converts accelerometer readings to m/s^2
-    double conversionFactor = (scale / MAX_RAW_SENSOR_READING) * G_FORCE;
+    double conversionFactor = sensitivity * ACCELEROMETER_OUTPUT_TO_MPS_SQUARED;
     
     return new Vector3(
-        accVec.getX() * conversionFactor,
-        accVec.getY() * conversionFactor,
-        accVec.getZ() * conversionFactor
+        accX * conversionFactor,
+        accY * conversionFactor,
+        accZ * conversionFactor
+    );
+  }
+  
+  /**
+   * Converts gyroscope readings to radians per second. Uses the current gyroscope scale setting.
+   * @param gyroX x-axis reading from gyroscope
+   * @param gyroY y-axis reading from gyroscope
+   * @param gyroZ z-axis reading from gyroscope
+   * @return the rotation vector in radians per second
+   */
+  public Vector3 computeAngularAcceleration(int gyroX, int gyroY, int gyroZ) {
+    // Get the gyroscope sensitivity.
+    double sensitivity;
+    switch(gyroScale) {
+    case DPS_245:
+      sensitivity = Settings.LSM9DS1_SENSITIVITY_GYROSCOPE_245DPS;
+      break;
+    case DPS_500:
+      sensitivity = Settings.LSM9DS1_SENSITIVITY_GYROSCOPE_500DPS;
+      break;
+    case DPS_2000:
+      sensitivity = Settings.LSM9DS1_SENSITIVITY_GYROSCOPE_2000DPS;
+      break;
+    default:
+      throw new IllegalStateException("Sensor has an unknown gyroscope scale.");
+    }
+    
+    // This factor converts gyroscope readings to radians per second
+    double conversionFactor = sensitivity * ONE_DEGREE_IN_RADIANS;
+    
+    return new Vector3(
+        gyroX * conversionFactor,
+        gyroY * conversionFactor,
+        gyroZ * conversionFactor
     );
   }
 

--- a/src/org/rocketproplab/marginalstability/flightcomputer/math/Vector3.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/math/Vector3.java
@@ -1,5 +1,7 @@
 package org.rocketproplab.marginalstability.flightcomputer.math;
 
+import org.rocketproplab.marginalstability.flightcomputer.Settings;
+
 /**
  * A vector class
  * 
@@ -50,11 +52,10 @@ public class Vector3 {
     if (!(other instanceof Vector3)) {
       return false;
     }
-    final double EQUAL_TOLERANCE = 0.000000001; // TODO may need adjusting
     Vector3 otherVector = (Vector3) other;
-    return (Math.abs(this.x - otherVector.x) < EQUAL_TOLERANCE) &&
-           (Math.abs(this.y - otherVector.y) < EQUAL_TOLERANCE) &&
-           (Math.abs(this.z - otherVector.z) < EQUAL_TOLERANCE);
+    return (Math.abs(this.x - otherVector.x) < Settings.EQUALS_EPSILON) &&
+           (Math.abs(this.y - otherVector.y) < Settings.EQUALS_EPSILON) &&
+           (Math.abs(this.z - otherVector.z) < Settings.EQUALS_EPSILON);
   }
 
   @Override

--- a/src/org/rocketproplab/marginalstability/flightcomputer/math/Vector3.java
+++ b/src/org/rocketproplab/marginalstability/flightcomputer/math/Vector3.java
@@ -50,8 +50,11 @@ public class Vector3 {
     if (!(other instanceof Vector3)) {
       return false;
     }
+    final double EQUAL_TOLERANCE = 0.000000001; // TODO may need adjusting
     Vector3 otherVector = (Vector3) other;
-    return this.x == otherVector.x && this.y == otherVector.y && this.z == otherVector.z;
+    return (Math.abs(this.x - otherVector.x) < EQUAL_TOLERANCE) &&
+           (Math.abs(this.y - otherVector.y) < EQUAL_TOLERANCE) &&
+           (Math.abs(this.z - otherVector.z) < EQUAL_TOLERANCE);
   }
 
   @Override

--- a/test/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyroTest.java
+++ b/test/org/rocketproplab/marginalstability/flightcomputer/hal/LSM9DS1AccelGyroTest.java
@@ -1,6 +1,7 @@
 package org.rocketproplab.marginalstability.flightcomputer.hal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -50,6 +51,22 @@ public class LSM9DS1AccelGyroTest {
     ctrlReg6XL = mockI2C.writeMap.get(Registers.CTRL_REG6_XL.getAddress());
     assertEquals((byte) 0b11110111, ctrlReg6XL);
   }
+  
+  @Test
+  public void getAccScaleReturnsCorrectScale() throws IOException {
+    mockI2C.readMap.put(LSM9DS1AccelGyro.Registers.CTRL_REG6_XL.getAddress(), (byte) 0);
+    assertEquals(imu.getAccelerometerScale(), AccelerometerScale.G_2);
+    
+    imu.setAccelerometerScale(AccelerometerScale.G_4);
+    assertEquals(imu.getAccelerometerScale(), AccelerometerScale.G_4);
+    assertNotEquals(imu.getAccelerometerScale(), AccelerometerScale.G_2);
+    
+    imu.setAccelerometerScale(AccelerometerScale.G_8);
+    assertEquals(imu.getAccelerometerScale(), AccelerometerScale.G_8);
+    
+    imu.setAccelerometerScale(AccelerometerScale.G_16);
+    assertEquals(imu.getAccelerometerScale(), AccelerometerScale.G_16);
+  }
 
   @Test
   public void setGyroScaleSetsScaleInREG1G() throws IOException {
@@ -62,6 +79,22 @@ public class LSM9DS1AccelGyroTest {
     imu.setGyroscopeScale(GyroScale.DPS_245);
     ctrlReg1G = mockI2C.writeMap.get(Registers.CTRL_REG1_G.getAddress());
     assertEquals((byte) 0b11100111, ctrlReg1G);
+  }
+  
+  @Test
+  public void getGyroScaleReturnsCorrectScale() throws IOException {
+    mockI2C.readMap.put(LSM9DS1AccelGyro.Registers.CTRL_REG1_G.getAddress(), (byte) 0);
+    assertEquals(imu.getGyroscopeScale(), GyroScale.DPS_NA);
+    
+    imu.setGyroscopeScale(GyroScale.DPS_245);
+    assertEquals(imu.getGyroscopeScale(), GyroScale.DPS_245);
+    assertNotEquals(imu.getGyroscopeScale(), GyroScale.DPS_NA);
+    
+    imu.setGyroscopeScale(GyroScale.DPS_500);
+    assertEquals(imu.getGyroscopeScale(), GyroScale.DPS_500);
+    
+    imu.setGyroscopeScale(GyroScale.DPS_2000);
+    assertEquals(imu.getGyroscopeScale(), GyroScale.DPS_2000);
   }
 
   @Test
@@ -227,5 +260,18 @@ public class LSM9DS1AccelGyroTest {
     expectedGyro = new Vector3(0x300, 0x100, 0);
     assertEquals(expectedGyro, gyro);
     assertFalse(imu.hasNext());
+  }
+  
+  @Test
+  public void computeAccelerationReturnsCorrectAcceleration() throws IOException {
+    mockI2C.readMap.put(LSM9DS1AccelGyro.Registers.CTRL_REG6_XL.getAddress(), (byte) 0);
+    Vector3 accReading = new Vector3(53.153, 28135.182, 18343.5465);
+    assertEquals(imu.computeAcceleration(accReading), new Vector3(0.03181572115, 16.84083880491, 10.97987244998));
+    
+    imu.setAccelerometerScale(AccelerometerScale.G_16);
+    assertEquals(imu.computeAcceleration(accReading), new Vector3(0.25452576919, 134.72671043931, 87.83897959983));
+    
+    accReading = new Vector3(32767, 32767, 32767);
+    assertEquals(imu.computeAcceleration(accReading), new Vector3(156.9064, 156.9064, 156.9064));
   }
 }


### PR DESCRIPTION
- Accelerometer and gyroscope readings are normalized to m/s^2 and rad/sec respectively.
- The conversion is computed based on the current range of the sensors.